### PR TITLE
(GH-11) Add alias to create snk file

### DIFF
--- a/src/cake.strongnametool/StrongNameCreateToolAliases.cs
+++ b/src/cake.strongnametool/StrongNameCreateToolAliases.cs
@@ -1,0 +1,42 @@
+using System;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.StrongNameTool
+{
+    /// <summary>
+    /// Strong Name (sn.exe) tool aliases.static It is possible to create a new snk file
+    /// by passing the path to the file that you want to create.
+    /// </summary>
+    [CakeAliasCategoryAttribute("Strong Naming")]
+    public static class StrongNameCreateToolAliases
+    {
+        /// <summary>
+        /// Uses sn.exe to create a new strong name key file.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="strongNameKeyFilePath">The path for the new strong name key file.</param>
+        /// <example>
+        /// <code>
+        /// Task("Create-Strong-Key-File")
+        ///     .Does(() =>
+        /// {
+        ///     var file = "test.snk";
+        ///     StrongNameReSign(file);
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        public static void StrongNameCreate(this ICakeContext context, FilePath strongNameKeyFilePath)
+        {
+            if (strongNameKeyFilePath == null)
+            {
+                throw new ArgumentNullException("strongNameKeyFilePath");
+            }
+
+            var runner = new StrongNameToolRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Registry);
+            runner.Run(strongNameKeyFilePath);
+        }
+    }
+}

--- a/src/cake.strongnametool/StrongNameToolRunner.cs
+++ b/src/cake.strongnametool/StrongNameToolRunner.cs
@@ -61,6 +61,24 @@ namespace Cake.StrongNameTool
         }
 
         /// <summary>
+        /// Run sn.exe specifically for the create command, passing in the name of the file to create.
+        /// </summary>
+        /// <param name="strongNameKeyFilePath">The path of the key that should be created.</param>
+        public void Run(FilePath strongNameKeyFilePath)
+        {
+            if(strongNameKeyFilePath.IsRelative)
+            {
+                strongNameKeyFilePath = strongNameKeyFilePath.MakeAbsolute(_environment);
+            }
+
+            var builder = new ProcessArgumentBuilder();
+            builder.Append("-k");
+            builder.AppendQuoted(strongNameKeyFilePath.FullPath);
+
+            Run(new StrongNameToolSettings(), builder);
+        }
+
+        /// <summary>
         /// Gets the arguments based on command and settings.
         /// </summary>
         /// <returns>The arguments.</returns>
@@ -83,7 +101,7 @@ namespace Cake.StrongNameTool
                 // verify
                 if (settings.ForceVerification) {
                     builder.Append ("-vf");
-                } 
+                }
                 else {
                     builder.Append ("-v");
                 }

--- a/src/cake.strongnametool/cake.strongnametool.csproj
+++ b/src/cake.strongnametool/cake.strongnametool.csproj
@@ -65,12 +65,13 @@
     <Compile Include="StrongNameToolSettings.cs" />
     <Compile Include="StrongNameReSignToolAliases.cs" />
     <Compile Include="StrongNameVerifyToolAliases.cs" />
+    <Compile Include="StrongNameCreateToolAliases.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
New alias StrongNameCreate has been added to allow execution of
sn.exe -k test.snk, for creating a new snk file as part of a build.

Resolves #11 